### PR TITLE
MacOS não é permitido utilizar teclas de atalho padrões como Ctrl C / Ctrl V / Ctrl A / etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1 
+
+- Add shortcut keys for mac users (Undo, Redo, Cut, Copy, Paste, Paste and Match Style, Delete, Select All, Speech, AutoFiil, Start Dictation)
+
 # 1.0.0 - Initial release version
 
 - Updated some default settings values

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fluig-monitor",
   "description": "Application for monitoring Fluig environments.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "build": "concurrently \"npm run build:main\" \"npm run build:renderer\"",
     "build:main": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.prod.ts && ts-node ./scripts/copySchema.ts",
@@ -131,6 +131,10 @@
       "name": "Luiz Ferreira",
       "email": "luizfernando_lf@hotmail.com.br",
       "url": "https://github.com/luizf-lf"
+    },
+    {
+      "name": "Pablo Valle",
+      "url": "https://github.com/pablooav"
     }
   ],
   "license": "MIT",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,13 +1,19 @@
 {
   "name": "fluig-monitor",
   "description": "Application for monitoring Fluig environments.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./dist/main/main.js",
   "author": {
     "name": "Luiz Ferreira",
     "email": "luizfernando_lf@hotmail.com.br",
     "url": "https://github.com/luizf-lf"
   },
+  "contributors": [
+    {
+      "name": "Pablo Valle",
+      "url": "https://github.com/pablooav"
+    }
+  ],
   "scripts": {
     "electron-rebuild": "node -r ts-node/register ../../.erb/scripts/electron-rebuild.js",
     "link-modules": "node -r ts-node/register ../../.erb/scripts/link-modules.ts",

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -75,6 +75,20 @@ export default class MenuBuilder {
             this.mainWindow.webContents.toggleDevTools();
           },
         },
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'pasteAndMatchStyle' },
+        { role: 'delete' },
+        { role: 'selectAll' },
+        { type: 'separator' },
+        {
+          label: 'Speech',
+          submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }],
+        },
       ],
     };
     const subMenuViewProd: MenuItemConstructorOptions = {
@@ -86,6 +100,20 @@ export default class MenuBuilder {
           click: () => {
             this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen());
           },
+        },
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'pasteAndMatchStyle' },
+        { role: 'delete' },
+        { role: 'selectAll' },
+        { type: 'separator' },
+        {
+          label: 'Speech',
+          submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }],
         },
       ],
     };

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -75,6 +75,20 @@ export default class MenuBuilder {
             this.mainWindow.webContents.toggleDevTools();
           },
         },
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'pasteAndMatchStyle' },
+        { role: 'delete' },
+        { role: 'selectAll' },
+        { type: 'separator' },
+        {
+          label: 'Speech',
+          submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }],
+        },
       ],
     };
     const subMenuViewProd: MenuItemConstructorOptions = {


### PR DESCRIPTION
Utilizo macbook e vi que não é possível utilizar teclas de atalho o que acaba tornando a utilização bem complexa porque funções básicas como copiar uma secret key não é possível e sou obrigado a realizar o preenchimento manual, então implementei seguindo o padrão que vi em outros apps no macOS, onde estes atalhos ficam na aba **Edit.**

Foi implementado os seguintes atalhos: Undo, Redo, Cut, Copy, Paste, Paste and Match Style, Delete, Select All, Speech, AutoFiil, Start Dictation.

Print do app do WhatsApp de exemplo:
![Screenshot 2023-11-07 at 16 46 13](https://github.com/luizf-lf/fluig-monitor/assets/43736318/86c9d1de-0e22-44c2-b151-dde21d8caed0)

Print de como ficou o Fluig Monitor:
![Screenshot 2023-11-07 at 16 46 33](https://github.com/luizf-lf/fluig-monitor/assets/43736318/c187e065-1eb4-4310-bbc4-6997b8d4c2f7)

